### PR TITLE
Update version to 0.2.0 and add trailing slash option for folder paths

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run build:*)",
+      "Bash(npm install:*)",
+      "Bash(ls:*)",
+      "Bash(npm run lint)"
+    ],
+    "deny": []
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ data.json
 dist
 .env
 /tsconfig.tsbuildinfo
+claude.md

--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ To install the latest release of this plugin, follow these steps:
 
 - **"Copy vault path" context menu action**: Show the option to copy the vault path of a file or folder.
 - **"Copy full path" context menu action**: Show the option to copy the full path of a file or folder.
-- **Add trailing slash to folder paths**: When enabled, folder paths will end with a trailing slash (e.g., `folder/`) to distinguish them from files. This applies to both vault and full path copying.
+- **"Add trailing slash to folder paths"**: When enabled, folder paths will end with a trailing slash (e.g., `folder/`) to distinguish them from files. This applies to both vault and full path copying.
 
 You can toggle these settings in the plugin's settings tab.

--- a/README.md
+++ b/README.md
@@ -16,5 +16,6 @@ To install the latest release of this plugin, follow these steps:
 
 - **"Copy vault path" context menu action**: Show the option to copy the vault path of a file or folder.
 - **"Copy full path" context menu action**: Show the option to copy the full path of a file or folder.
+- **Add trailing slash to folder paths**: When enabled, folder paths will end with a trailing slash (e.g., `folder/`) to distinguish them from files. This applies to both vault and full path copying.
 
 You can toggle these settings in the plugin's settings tab.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copy-path",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Adds context menu actions for copying the vault or full paths of files and folders.",
   "keywords": [],
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copy-path",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "description": "Adds context menu actions for copying the vault or full paths of files and folders.",
   "keywords": [],
   "license": "MIT",

--- a/src/Plugin.ts
+++ b/src/Plugin.ts
@@ -1,6 +1,9 @@
 import type { TAbstractFile } from 'obsidian';
 
-import { Notice } from 'obsidian';
+import {
+  Notice,
+  TFolder
+} from 'obsidian';
 import { PluginBase } from 'obsidian-dev-utils/obsidian/Plugin/PluginBase';
 
 import type { CopyPathPluginTypes } from './PluginTypes.ts';
@@ -29,7 +32,7 @@ export class CopyPathPlugin extends PluginBase<CopyPathPluginTypes> {
               .setTitle('Copy vault path')
               .setIcon('copy')
               .onClick(async () => {
-                await copyVaultPath(file);
+                await copyVaultPath(file, this);
               });
           });
         }
@@ -54,15 +57,28 @@ async function copyFullPath(
   file: TAbstractFile,
   plugin: CopyPathPlugin
 ): Promise<void> {
-  const absolutePath = plugin.app.vault.adapter.getFullRealPath(file.path);
+  let absolutePath = plugin.app.vault.adapter.getFullRealPath(file.path);
+
+  if (file instanceof TFolder && plugin.settings.addTrailingSlashToFolders) {
+    absolutePath += '/';
+  }
+
   await navigator.clipboard.writeText(absolutePath);
   // eslint-disable-next-line no-magic-numbers
   new Notice(`Copied full path:\n${absolutePath}`, 2000);
 }
 
 // Is normalized.
-async function copyVaultPath(file: TAbstractFile): Promise<void> {
-  const vaultPath = file.path;
+async function copyVaultPath(
+  file: TAbstractFile,
+  plugin: CopyPathPlugin
+): Promise<void> {
+  let vaultPath = file.path;
+
+  if (file instanceof TFolder && plugin.settings.addTrailingSlashToFolders) {
+    vaultPath += '/';
+  }
+
   await navigator.clipboard.writeText(vaultPath);
   // eslint-disable-next-line no-magic-numbers
   new Notice(`Copied vault path:\n${vaultPath}`, 2000);

--- a/src/PluginSettings.ts
+++ b/src/PluginSettings.ts
@@ -1,4 +1,5 @@
 export class CopyPathPluginSettings {
+  public addTrailingSlashToFolders = true;
   public copyFullPathContextItem = true;
   public copyVaultPathContextItem = true;
 }

--- a/src/PluginSettingsTab.ts
+++ b/src/PluginSettingsTab.ts
@@ -19,5 +19,12 @@ export class CopyPathPluginSettingsTab extends PluginSettingsTabBase<CopyPathPlu
       .addToggle((toggle) => {
         this.bind(toggle, 'copyFullPathContextItem');
       });
+
+    new SettingEx(this.containerEl)
+      .setName('Add trailing slash to folder paths')
+      .setDesc('When copying folder paths, append a trailing slash to distinguish them from files')
+      .addToggle((toggle) => {
+        this.bind(toggle, 'addTrailingSlashToFolders');
+      });
   }
 }


### PR DESCRIPTION
Increment the version number and introduce an option to append a trailing slash when copying folder paths, enhancing clarity in distinguishing between files and folders. Local settings have also been included.

implements #2 